### PR TITLE
Add reference to educast.nrw 9.x workflows

### DIFF
--- a/9.x/educast.nrw/README.md
+++ b/9.x/educast.nrw/README.md
@@ -1,0 +1,12 @@
+# educast.nrw Opencast 9.x Workflows
+
+The [educast.nrw](https://educast.nrw) Opencast workflows for 9.x as well as a test set of media files are available
+publicly [in this Git repository](https://zivgitlab.uni-muenster.de/educast-nrw/opencast/workflows/-/tree/educast/9).
+Note that the workflows might require the patches [educast.nrw](https://educast.nrw) applies to
+[Opencast](https://zivgitlab.uni-muenster.de/educast-nrw/opencast/opencast/-/tree/educast/9),
+[FFmpeg](https://zivgitlab.uni-muenster.de/educast-nrw/opencast/ffmpeg), and other dependencies that are not (yet)
+available upstream.
+
+An extended test set covering a wide variety of possible input files is available in the [`educast/9-ext`
+branch](https://zivgitlab.uni-muenster.de/educast-nrw/opencast/workflows/-/tree/educast/9-ext) (see folder `tests/media`). You will need [Git Large
+File Storage (LFS)](https://git-lfs.github.com/) to retrieve these files.


### PR DESCRIPTION
Since we will continue working on these, I only added a reference to our Git repository.